### PR TITLE
Dependency fix, and function argument fix.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [io.replikativ/datahike "0.2.2-SNAPSHOT"]
                  [com.datomic/client-cloud "0.8.78" :scope "provided"]
-                 #_[com.datomic/datomic-free "0.9.5697" :scope "provided"]]
+                 [com.cognitect/transit-clj "0.8.313"]]
   :profiles {:dev {:dependencies [[org.clojure/test.check "0.9.0"]]}}
   :repl-options {:init-ns wanderung.core})

--- a/src/wanderung/core.clj
+++ b/src/wanderung/core.clj
@@ -4,8 +4,7 @@
             [wanderung.datomic :as wd]))
 
 (defn datomic->datahike [datomic-config datomic-name datahike-config]
-  (let [datomic-conn (dt/connect datomic-config)
-        datomic-data (wd/extract-datomic-data datomic-conn {:db-name datomic-name})
+  (let [datomic-conn (dt/connect (dt/client datomic-config) {:db-name datomic-name})
+        datomic-data (wd/extract-datomic-data datomic-conn)
         datahike-conn (d/connect datahike-config)]
     @(d/migrate datahike-conn datomic-data)))
-


### PR DESCRIPTION
Using the version of [com.cognitect/transit-clj] loaded by [com.datomic/client-cloud "0.8.78"],
the version of com.cognitect.transit.TransitFactory.writer with the
correct signature is missing, causing:

java.lang.NoSuchMethodError: 'com.cognitect.transit.Writer
com.cognitect.transit.TransitFactory.writer(com.cognitect.transit.TransitFactory$Format,
java.io.OutputStream, java.util.Map,
com.cognitect.transit.WriteHandler, java.util.function.Function)'

This is circumvented by explicitly loading a newer version  [com.cognitect/transit-clj "0.8.313"].