### PR TITLE
Allow entity ids to be strings in datoms

### DIFF
--- a/src/wanderung/datom.clj
+++ b/src/wanderung/datom.clj
@@ -1,7 +1,7 @@
 (ns wanderung.datom
   (:require [clojure.spec.alpha :as spec]))
 
-(spec/def :datom/eid number?)
+(spec/def :datom/eid (spec/or :id number? :tempid string?))
 (spec/def :datom/attribute keyword?)
 (spec/def :datom/value any?)
 (spec/def :datom/transaction-id :datom/eid)

--- a/src/wanderung/datomic_cloud.clj
+++ b/src/wanderung/datomic_cloud.clj
@@ -116,5 +116,5 @@
                                          v) tx added])))
         data-extract (mapcat (fn [{:keys [data]}]
                                (into [] map-db-ident data)))
-        tx-data (d/tx-range conn {:start start-tx})]
+        tx-data (d/tx-range conn {:start start-tx :limit -1})]
     (into [] data-extract tx-data)))


### PR DESCRIPTION
We are using wanderung for rewriting history (i.e. adding new datoms with tempids), and one problem with existing spec is that is disallows tempids, while the actual migration process seem to work fine.

I'm not sure whether support for rewriting history is in scope for wanderung, if it isn't, feel free to decline the PR!