### PR TITLE
Make it possible to load a database nippy file from a Jar-file

### DIFF
--- a/src/wanderung/core.clj
+++ b/src/wanderung/core.clj
@@ -35,6 +35,10 @@
 (defmethod datoms-from-storage :nippy [storage]
   (nippy/thaw-from-file (:filename storage)))
 
+;;; Nippy JAR
+(defmethod datoms-from-storage :nippy-jar [storage]
+  (nippy/thaw-from-resource (:filename storage)))
+
 (defmethod datoms-to-storage :nippy [storage datoms]
   (let [filename (:filename storage)]
     (io/make-parents filename)


### PR DESCRIPTION
Set the `:wanderung/type` to `:nippy-jar`, to be able to read database nippy files from inside a Jar-file that your project has as a dependency.

Example config: 

```clojure
{:wanderung/type :nippy-jar
 :filename "my-database.nippy"}
```

